### PR TITLE
Various fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:alpine-3.12
+ENV USERNAME=vscode
+
+
+
+RUN apk add --no-cache git shellcheck vim wget curl shadow
+RUN apk add --no-cache nodejs npm
+RUN wget -qO- "https://github.com/hadolint/hadolint/releases/download/v1.17.3/hadolint-Linux-x86_64" > hadolint \
+    && cp "hadolint" /usr/bin/ \
+    && chmod +x /usr/bin/hadolint
+
+
+
+# hadolint ignore=DL3016
+RUN npm install -g bats
+# hadolint ignore=DL3013
+RUN npm install -g markdownlint-cli
+
+USER $USERNAME
+
+RUN mkdir -p /home/$USERNAME/.vscode-server/extensions \
+        /home/$USERNAME/.vscode-server-insiders/extensions \
+    && chown -R $USERNAME \
+        /home/$USERNAME/.vscode-server \
+        /home/$USERNAME/.vscode-server-insiders

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "${localWorkspaceFolderBasename}",
+    "dockerFile": "./Dockerfile",
+    "remoteUser": "vscode",
+    "mounts": [
+        "source=${localWorkspaceFolderBasename}-extensions,target=/home/vscode/.vscode-server/extensions,type=volume,consistency=cached",
+        // keep the trailing comma below so it can be used in tests
+        "source=${localWorkspaceFolderBasename}-extensions-insiders,target=/home/vscode/.vscode-server-insiders/extensions,type=volume,consistency=cached",
+    ],
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+    "updateRemoteUserUID": true,
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "workspaceFolder": "/workspace",
+    "extensions": [
+       "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+       "exiasr.hadolint",
+    ],
+}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,11 @@
+name: 'Trigger: Push action'
+on: [push]
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-.devcontainer
+# .devcontainer
+.history

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ Example
 
 ![Example](example.gif)
 
+## Usage
+
+Running the `.devcontainer.json` file in this repository can be done using the following command:
+```
+.devcontainer.sh -v --docker-opts="-u root"
+```
+The `--docker-opts` are necessary because by default the vscode image runs as vscode user (id 1000)
+
+
 ## How does it work?
 The script can be run in any workspace the contains the `.devcontainer` configuration folder. On start, it parses several different options from the `devcontainer.json` file, builds the dockerfile, and starts the container. The script mounts the current folder into the container into the `/workspaces/$currentfolder` path. Same as Visual Studio Code does. 
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@ You can install the devcontainer script by either [downloading the script](https
 ```
 sudo sh -c 'curl -s https://raw.githubusercontent.com/BorisWilhelms/devcontainer/main/devcontainer.sh > /usr/local/bin/devcontainer && chmod +x /usr/local/bin/devcontainer'
 ```
-### Prerequisites
+## Prerequisites
 The script uses [jq](https://stedolan.github.io/jq/) to parse the `devcontainer.json`. Therefore it must be installed.
+Also GNU sed need to be installed
+
 
 ## Known issues
 - Since `jq` expects a valid JSON file, all possible JSON error (e.g. `,` without following properties) has to be corrected. The script will strip all comments (`//`) to make it more valid.
+
+
+## Development
+
+### Run shellcheck
+`git ls-files | grep '.sh' | xargs shellcheck`

--- a/README.md
+++ b/README.md
@@ -24,11 +24,8 @@ sudo sh -c 'curl -s https://raw.githubusercontent.com/BorisWilhelms/devcontainer
 ```
 ## Prerequisites
 The script uses [jq](https://stedolan.github.io/jq/) to parse the `devcontainer.json`. Therefore it must be installed.
-Also GNU sed need to be installed
+Also `GNU sed` needs to be installed
 
-
-## Known issues
-- Since `jq` expects a valid JSON file, all possible JSON error (e.g. `,` without following properties) has to be corrected. The script will strip all comments (`//`) to make it more valid.
 
 
 ## Development

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -165,7 +165,7 @@ docker run -it $DOCKER_OPTS $PORTS $ENVS $MOUNT -w "$WORK_DIR" "$DOCKER_TAG" "$S
 if [[ '$REMOTE_USER' != '' ]] && command -v usermod &>/dev/null; \
 then \
     sudo=''
-    if [[ \"$(stat -f -c '%u' \"$(which sudo)\")\" = '0' ]]; then
+    if [[ \"$(stat -f -c '%u' "$(which sudo)")\" = '0' ]]; then
         sudo=sudo
     fi
     \$sudo usermod -u $PUID $REMOTE_USER && \

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -16,25 +16,71 @@ if ! sed --version | grep "sed (GNU sed)" &>/dev/null; then
 fi
 
 VERBOSE=0
-
-while getopts "v" opt; do
-    case ${opt} in
-        v ) VERBOSE=1 ;;
-    esac
-done
+DOCKER_OPTS=""
 
 debug() {
     if [ $VERBOSE == 1 ]; then
-        printf "\x1B[33m[DEBUG] ${1}\x1B[0m\n"
+        printf "\x1B[33m[DEBUG] %s\x1B[0m\n" "${1}"
     fi
 }
 
-WORKSPACE=${1:-`pwd`}
-CURRENT_DIR=${PWD##*/}
+optspec=":v-:"
+while getopts "$optspec" opt; do
+    case ${opt} in
+        v ) 
+            val="${!OPTIND}"
+            VERBOSE=1
+            ;;
+        -)
+            case "${OPTARG}" in
+                docker-opts)
+                    val="${!OPTIND}"; OPTIND=$((OPTIND + 1))
+                    DOCKER_OPTS=$val
+                    if [[ $VERBOSE  = 1 ]]; then
+                        debug "Setting DOCKER_OPTS $DOCKER_OPTS"
+                    fi
+                    ;;
+                docker-opts=*)
+                    val=${OPTARG#*=}
+                    opt=${OPTARG%=$val}
+                    DOCKER_OPTS=$val
+                    if [[ $VERBOSE = 1 ]]; then
+                        debug "Setting DOCKER_OPTS $DOCKER_OPTS"
+                    fi
+                    debug "docker-opts=* optind $OPTIND"
+                    ;;
+                
+                *)
+                    if [ "$OPTERR" = 1 ]; then
+                        echo "Unknown option --${OPTARG}" >&2
+                        exit 5
+                    fi
+                    ;;
+            esac;;
+        *)
+            if [ "$OPTERR" = 1 ]; then
+                echo "Unknown option -${OPTARG}" >&2
+                exit 5
+            fi
+            ;;
+    esac
+done
+
+
+WORKSPACE="${*:$OPTIND:1}"
+WORKSPACE="${WORKSPACE:-$PWD}"
+
+if [[ ! -d "$WORKSPACE" ]]; then
+    echo "Directory $WORKSPACE does not exist!" >&2
+    exit 6
+fi
+
+
 echo "Using workspace ${WORKSPACE}"
 
 CONFIG_DIR=./.devcontainer
 debug "CONFIG_DIR: ${CONFIG_DIR}"
+
 CONFIG_FILE=devcontainer.json
 debug "CONFIG_FILE: ${CONFIG_FILE}"
 if ! [ -e "$CONFIG_DIR/$CONFIG_FILE" ]; then
@@ -65,32 +111,30 @@ fi
 
 cd "$CONFIG_DIR" || return
 
+DOCKER_FILE=$(echo "$CONFIG" | jq -r .dockerFile)
 if [ "$DOCKER_FILE" == "null" ]; then 
-    DOCKER_FILE=$(echo $CONFIG | jq -r .build.dockerfile)
+    DOCKER_FILE=$(echo "$CONFIG" | jq -r .build.dockerfile)
 fi
-DOCKER_FILE=$(readlink -f $DOCKER_FILE)
+DOCKER_FILE="$(readlink -f "$DOCKER_FILE")"
 debug "DOCKER_FILE: ${DOCKER_FILE}"
-if ! [ -e $DOCKER_FILE ]; then
+if ! [ -e "$DOCKER_FILE" ]; then
     echo "Can not find dockerfile ${DOCKER_FILE}"
     exit
 fi
 
-REMOTE_USER=$(echo $CONFIG | jq -r .remoteUser)
+REMOTE_USER="$(echo "$CONFIG" | jq -r .remoteUser)"
 debug "REMOTE_USER: ${REMOTE_USER}"
-if ! [ "$REMOTE_USER" == "null" ]; then
-    REMOTE_USER="-u ${REMOTE_USER}"
-fi
 
-ARGS=$(echo $CONFIG | jq -r '.build.args | to_entries? | map("--build-arg \(.key)=\"\(.value)\"")? | join(" ")')
+ARGS=$(echo "$CONFIG" | jq -r '.build.args | to_entries? | map("--build-arg \(.key)=\"\(.value)\"")? | join(" ")')
 debug "ARGS: ${ARGS}"
 
-SHELL=$(echo $CONFIG | jq -r '.settings."terminal.integrated.shell.linux"')
+SHELL=$(echo "$CONFIG" | jq -r '.settings."terminal.integrated.shell.linux"')
 debug "SHELL: ${SHELL}"
 
-PORTS=$(echo $CONFIG | jq -r '.forwardPorts | map("-p \(.):\(.)")? | join(" ")')
+PORTS=$(echo "$CONFIG" | jq -r '.forwardPorts | map("-p \(.):\(.)")? | join(" ")')
 debug "PORTS: ${PORTS}"
 
-ENVS=$(echo $CONFIG | jq -r '.remoteEnv | to_entries? | map("-e \(.key)=\(.value)")? | join(" ")')
+ENVS=$(echo "$CONFIG" | jq -r '.remoteEnv | to_entries? | map("-e \(.key)=\(.value)")? | join(" ")')
 debug "ENVS: ${ENVS}"
 
 WORK_DIR="/workspace"
@@ -100,7 +144,25 @@ MOUNT="${MOUNT} --mount type=bind,source=${WORKSPACE},target=${WORK_DIR}"
 debug "MOUNT: ${MOUNT}"
 
 echo "Building and starting container"
-DOCKER_IMAGE_HASH=$(docker build -f $DOCKER_FILE $ARGS .)
-debug "DOCKER_IMAGE_HASH: ${DOCKER_IMAGE_HASH}"
 
-docker run -it $REMOTE_USER $PORTS $ENVS $MOUNT -w $WORK_DIR $DOCKER_IMAGE_HASH $SHELL
+DOCKER_TAG=$(echo "$DOCKER_FILE" | md5sum - | awk '{ print $1 }')
+# shellcheck disable=SC2086
+docker build -f "$DOCKER_FILE" -t "$DOCKER_TAG" $ARGS .
+
+debug "DOCKER_TAG: ${DOCKER_TAG}"
+
+PUID=$(id -u)
+PGID=$(id -g)
+
+# shellcheck disable=SC2086
+docker run -it $DOCKER_OPTS $PORTS $ENVS $MOUNT -w "$WORK_DIR" "$DOCKER_TAG" "$SHELL" -c "\
+if [[ '$REMOTE_USER' != '' ]] && command -v usermod &>/dev/null; \
+then \
+    sudo usermod -u $PUID $REMOTE_USER && \
+    sudo groupmod -g $PGID $REMOTE_USER && \
+    sudo passwd -d $REMOTE_USER && \
+    sudo chown $REMOTE_USER:$REMOTE_USER -R ~$REMOTE_USER $WORK_DIR && \
+    su $REMOTE_USER -s $SHELL; \
+else \
+    $SHELL; \
+fi"

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -148,6 +148,12 @@ echo "Building and starting container"
 DOCKER_TAG=$(echo "$DOCKER_FILE" | md5sum - | awk '{ print $1 }')
 # shellcheck disable=SC2086
 docker build -f "$DOCKER_FILE" -t "$DOCKER_TAG" $ARGS .
+build_status=$?
+
+if [[ $build_status -ne 0 ]]; then
+    echo "Building docker image failed..." >&2
+    exit 7
+fi
 
 debug "DOCKER_TAG: ${DOCKER_TAG}"
 

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -157,15 +157,16 @@ fi
 
 debug "DOCKER_TAG: ${DOCKER_TAG}"
 
+set -e
 PUID=$(id -u)
 PGID=$(id -g)
 
 # shellcheck disable=SC2086
 docker run -it $DOCKER_OPTS $PORTS $ENVS $MOUNT -w "$WORK_DIR" "$DOCKER_TAG" "$SHELL" -c "\
-if [[ '$REMOTE_USER' != '' ]] && command -v usermod &>/dev/null; \
+if [ '$REMOTE_USER' != '' ] && command -v usermod &>/dev/null; \
 then \
     sudo=''
-    if [[ \"$(stat -f -c '%u' "$(which sudo)")\" = '0' ]]; then
+    if [ \"$(stat -f -c '%u' "$(which sudo)")\" = '0' ]; then
         sudo=sudo
     fi
     \$sudo usermod -u $PUID $REMOTE_USER && \

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -165,7 +165,7 @@ docker run -it $DOCKER_OPTS $PORTS $ENVS $MOUNT -w "$WORK_DIR" "$DOCKER_TAG" "$S
 if [[ '$REMOTE_USER' != '' ]] && command -v usermod &>/dev/null; \
 then \
     sudo=''
-    if [[ "$(stat -f -c '%u' $(which sudo))" = '0' ]]; then
+    if [[ \"$(stat -f -c '%u' $(which sudo))\" = '0' ]]; then
         sudo=sudo
     fi
     \$sudo usermod -u $PUID $REMOTE_USER && \

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -165,7 +165,7 @@ docker run -it $DOCKER_OPTS $PORTS $ENVS $MOUNT -w "$WORK_DIR" "$DOCKER_TAG" "$S
 if [[ '$REMOTE_USER' != '' ]] && command -v usermod &>/dev/null; \
 then \
     sudo=''
-    if [[ \"$(stat -f -c '%u' $(which sudo))\" = '0' ]]; then
+    if [[ \"$(stat -f -c '%u' \"$(which sudo)\")\" = '0' ]]; then
         sudo=sudo
     fi
     \$sudo usermod -u $PUID $REMOTE_USER && \

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -164,10 +164,14 @@ PGID=$(id -g)
 docker run -it $DOCKER_OPTS $PORTS $ENVS $MOUNT -w "$WORK_DIR" "$DOCKER_TAG" "$SHELL" -c "\
 if [[ '$REMOTE_USER' != '' ]] && command -v usermod &>/dev/null; \
 then \
-    sudo usermod -u $PUID $REMOTE_USER && \
-    sudo groupmod -g $PGID $REMOTE_USER && \
-    sudo passwd -d $REMOTE_USER && \
-    sudo chown $REMOTE_USER:$REMOTE_USER -R ~$REMOTE_USER $WORK_DIR && \
+    sudo=''
+    if [[ "$(stat -f -c '%u' $(which sudo))" = '0' ]]; then
+        sudo=sudo
+    fi
+    \$sudo usermod -u $PUID $REMOTE_USER && \
+    \$sudo groupmod -g $PGID $REMOTE_USER && \
+    \$sudo passwd -d $REMOTE_USER && \
+    \$sudo chown $REMOTE_USER:$REMOTE_USER -R ~$REMOTE_USER $WORK_DIR && \
     su $REMOTE_USER -s $SHELL; \
 else \
     $SHELL; \


### PR DESCRIPTION
- Do not continue when Docker build fails
- Added --docker-opts so options can be passed to `docker run`
- Added Shellcheck Github action
- Remove trailing comma's in `devcontainer.json`
- Example `devcontainer.json` which has comments and trailing comma's in it to test with
- Replace variables in `devcontainer.json` (localWorkspaceFolderBasename and localWorkspaceFolder for now)
- Run `chmod` + `chown` when starting, just like Vs Code does